### PR TITLE
Adding platform versions to Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,7 @@ import PackageDescription
 
 let package = Package(
   name: "DynamoDB",
+  platforms: [.iOS(.v12), .tvOS(.v12), .watchOS(.v5)],
   products: [
       .library(name: "DynamoDB", targets: ["DynamoDB"]),
   ],


### PR DESCRIPTION
You can see the error in the screenshot below. The error happens when using Swift PM. Platform specification fixes the issue.

![1](https://user-images.githubusercontent.com/2674368/81674989-6bebb680-9491-11ea-9261-7b4249acda39.png)
